### PR TITLE
Add Meyer remittance parsing and display discounts

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -383,7 +383,24 @@ tbody input[type="checkbox"]{
 .invoice-cell{
   font-weight:600;
   color:var(--ink);
+  display:flex;
+  flex-direction:column;
+  gap:4px;
 }
+
+.invoice-number{font-weight:600;}
+
+.invoice-meta{
+  font-size:12px;
+  color:var(--muted);
+  display:flex;
+  flex-direction:column;
+  gap:2px;
+}
+
+.invoice-desc{word-break:break-word;}
+
+.invoice-discount{color:var(--good);font-weight:500;}
 
 .invoice-date{
   color:var(--muted);


### PR DESCRIPTION
## Summary
- add escaping and invoice metadata rendering so discounts and descriptions surface in the table
- capture discount/original columns when parsing spreadsheets and exports
- recognize Meyer Distributing remittance PDFs, extracting payment date, totals, and line items including discount data
- style invoice metadata for readability

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e529fbf00c832b9876fc0241fd10bc